### PR TITLE
Update Tomlyn to latest version (0.14.3)

### DIFF
--- a/Tomlyn.Extensions.Configuration.Tests/Tomlyn.Extensions.Configuration.Tests.csproj
+++ b/Tomlyn.Extensions.Configuration.Tests/Tomlyn.Extensions.Configuration.Tests.csproj
@@ -7,11 +7,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.4.0" />
+    <PackageReference Include="FluentAssertions" Version="6.6.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" PrivateAssets="all" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Tomlyn.Extensions.Configuration/TomlConfigurationFileParser.cs
+++ b/Tomlyn.Extensions.Configuration/TomlConfigurationFileParser.cs
@@ -68,10 +68,6 @@ namespace Tomlyn.Extensions.Configuration
                 case TomlArray tomlArray:
                     VisitArray(tomlArray);
                     break;
-                // The TomlDateTime case can be deleted once https://github.com/xoofx/Tomlyn/pull/21 is merged and released
-                case TomlDateTime tomlDateTime:
-                    _data.Add(_paths.Peek(), tomlDateTime.ToString());
-                    break;
                 default:
                     _data.Add(_paths.Peek(), Convert.ToString(obj, CultureInfo.InvariantCulture));
                     break;

--- a/Tomlyn.Extensions.Configuration/Tomlyn.Extensions.Configuration.csproj
+++ b/Tomlyn.Extensions.Configuration/Tomlyn.Extensions.Configuration.csproj
@@ -15,7 +15,7 @@
 
     <ItemGroup>
       <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="5.0.0" />
-      <PackageReference Include="Tomlyn" Version="0.10.0" />
+      <PackageReference Include="Tomlyn" Version="0.14.3" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
The workaround for converting a `TomlDateTime` to a string has been removed since it's not necessary anymore.