### PR TITLE
Feature/implement snake case .toml files properly.

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,33 @@ name = "Gina"
 Name = "Gina"
 ```
 
+## Snake Case Keys
+
+TOML file keys [usually follow the 'snake_case' naming convention](https://toml.io/en/v1.0.0#keys) along with 'PascalCase' variables that bind to the keys.
+
+```toml
+name_of_person = "Gina"
+```
+```cs
+string NameOfPerson = "Gina"
+```
+
+If your .toml file has any 'snake_case' keys, you can use the [`RemoveUnderscores`] method to modify the keys with underscores after the build and before the bind call.
+
+```cs
+var configuration = new ConfigurationBuilder()
+    .AddTomlFile("sample_with_underscores.toml")
+    .Build();
+
+// Modifying keys in the below line
+var config = configuration.RemoveUnderscores();
+
+// Bind the new ConfigurationBuilder called 'config' with the class to be bound
+config.Bind(sample);
+```
+
+If using 'snake_case' keys, YOU MUST make sure that your C# variables are 'PascalCase' to ensure proper binding. 
+
 ## Alternatives and benchmarks
 
 Another [possibly slightly faster](https://github.com/bugproof/TomlLibrariesBenchmark) alternative is [Tommy.Extensions.Configuration](https://github.com/dezhidki/Tommy/tree/master/Tommy.Extensions.Configuration).

--- a/Tomlyn.Extensions.Configuration.Tests/SampleWithUnderscores.cs
+++ b/Tomlyn.Extensions.Configuration.Tests/SampleWithUnderscores.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Collections.Generic;
+
+namespace Tomlyn.Extensions.Configuration.Tests;
+
+public class SampleWithUnderscores
+{
+    public string Title { get; init; } = "";
+    public OwnerOfToml OwnerOfToml { get; init; } = new();
+    public DatabaseInformation DatabaseInformation { get; init; } = new();
+    public Dictionary<string, Servers> Servers { get; init; } = new();
+
+}
+
+public class OwnerOfToml
+{
+    public string FullName { get; init; } = "";
+    public DateTime DateOfBirth { get; init; }
+}
+
+public class DatabaseInformation
+{
+    public bool IsEnabled { get; init; }
+    public ushort[] Ports { get; init; } = Array.Empty<ushort>();
+    public List<List<object>> DataValues { get; init; } = new();
+
+    public Dictionary<string, decimal> TempTargets { get; init; } = new();
+}
+
+public class Servers
+{
+    public string IpAddress { get; init; } = "";
+    public RoleInformation RoleInformation { get; init; }
+}
+
+public enum RoleInformation
+{
+    Unknown,
+    Frontend,
+    Backend,
+}

--- a/Tomlyn.Extensions.Configuration.Tests/TomlToSnakeCaseModifierTest.cs
+++ b/Tomlyn.Extensions.Configuration.Tests/TomlToSnakeCaseModifierTest.cs
@@ -18,7 +18,7 @@ public class TomlToSnakeCaseModifierTest
         
         // ONLY NECESSARY if your variable binding DOES NOT have underscores and is PascalCase.
         // E.g., pascal_case in your .toml file is mapped to PascalCase in your binding class NOT Pascal_Case.
-        var config = TomlToSnakeCaseModifier.RemoveUnderscores(configuration);
+        var config = configuration.RemoveUnderscores();
         config.Bind(sample);
 
         // The configuration system is type-agnostic and will not attempt to convert to numeric types

--- a/Tomlyn.Extensions.Configuration.Tests/TomlToSnakeCaseModifierTest.cs
+++ b/Tomlyn.Extensions.Configuration.Tests/TomlToSnakeCaseModifierTest.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Collections.Generic;
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Xunit;
+
+namespace Tomlyn.Extensions.Configuration.Tests;
+
+public class TomlToSnakeCaseModifierTest
+{
+    [Fact]
+    public void BindCorrect()
+    {
+        var sample = new SampleWithUnderscores();
+        var configuration = new ConfigurationBuilder()
+            .AddTomlFile("sample_with_underscores.toml")
+            .Build();
+        
+        // ONLY NECESSARY if your variable binding DOES NOT have underscores and is PascalCase.
+        // E.g., pascal_case in your .toml file is mapped to PascalCase in your binding class NOT Pascal_Case.
+        var config = TomlToSnakeCaseModifier.RemoveUnderscores(configuration);
+        config.Bind(sample);
+
+        // The configuration system is type-agnostic and will not attempt to convert to numeric types
+        // when the target is an object type given the DataValues variable declaration.
+        foreach (var item in sample.DatabaseInformation.DataValues)
+        {
+            for (int i = 0; i < item.Count; i++)
+            {
+                if (double.TryParse(item[i].ToString(), out double result))
+                {
+                    item[i] = result;
+                }
+            }
+        }
+
+        var expected = new SampleWithUnderscores
+        {
+            Title = "TOML Example",
+            OwnerOfToml = new OwnerOfToml
+            {
+                FullName = "Tom Preston-Werner",
+                DateOfBirth = new DateTime(1979, 05, 27),
+            },
+            DatabaseInformation = new DatabaseInformation
+            {
+                IsEnabled = true,
+                Ports = new ushort[] { 8000, 8001, 8002 },
+                DataValues = new List<List<object>>
+                {
+                    new List<object> { "delta", "phi" },
+                    new List<object> { 3.14 }
+                },
+                TempTargets = new Dictionary<string, decimal>
+                {
+                    ["cpu"] = 79.5m,
+                    ["case"] = 72m,
+                }
+            },
+            Servers = new Dictionary<string, Servers>
+            {
+                ["alpha"] = new()
+                {
+                    IpAddress = "10.0.0.1",
+                    RoleInformation = RoleInformation.Frontend,
+                },
+                ["beta"] = new()
+                {
+                    IpAddress = "10.0.0.2",
+                    RoleInformation = RoleInformation.Backend,
+                },
+            }
+        };
+        sample.Should().BeEquivalentTo(expected);
+    }
+}

--- a/Tomlyn.Extensions.Configuration.Tests/TomlToSnakeCaseModifierTest.cs
+++ b/Tomlyn.Extensions.Configuration.Tests/TomlToSnakeCaseModifierTest.cs
@@ -16,8 +16,8 @@ public class TomlToSnakeCaseModifierTest
             .AddTomlFile("sample_with_underscores.toml")
             .Build();
         
-        // ONLY NECESSARY if your variable binding DOES NOT have underscores and is PascalCase.
-        // E.g., pascal_case in your .toml file is mapped to PascalCase in your binding class NOT Pascal_Case.
+        // This is necessary to modify keys in your .toml file that have underscores. NOTE that if
+        // .toml file has underscores, you must ensure your C# bind file has 'PascalCase' names. 
         var config = configuration.RemoveUnderscores();
         config.Bind(sample);
 

--- a/Tomlyn.Extensions.Configuration.Tests/Tomlyn.Extensions.Configuration.Tests.csproj
+++ b/Tomlyn.Extensions.Configuration.Tests/Tomlyn.Extensions.Configuration.Tests.csproj
@@ -20,6 +20,9 @@
 
   <ItemGroup>
     <None Update="sample.toml" CopyToOutputDirectory="PreserveNewest" />
+    <None Update="sample_with_underscores.toml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
 </Project>

--- a/Tomlyn.Extensions.Configuration.Tests/sample_with_underscores.toml
+++ b/Tomlyn.Extensions.Configuration.Tests/sample_with_underscores.toml
@@ -1,0 +1,26 @@
+# This is a TOML document with proper TOML names being
+# snake_case. Using snake_case keys are usually standard
+# practice but is not documented.
+
+title = "TOML Example"
+
+[owner_of_toml]
+full_name = "Tom Preston-Werner"
+date_of_birth = 1979-05-27
+
+[database_information]
+is_enabled = true
+ports = [ 8000, 8001, 8002 ]
+data_values = [ ["delta", "phi"], [3.14] ]
+temp_targets = { cpu = 79.5, case = 72.0 }
+
+[servers]
+
+[servers.alpha]
+ip_address = "10.0.0.1"
+role_information = "Frontend"
+
+[servers.beta]
+ip_address = "10.0.0.2"
+role_information = "Backend"
+

--- a/Tomlyn.Extensions.Configuration.Tests/sample_with_underscores.toml
+++ b/Tomlyn.Extensions.Configuration.Tests/sample_with_underscores.toml
@@ -12,7 +12,7 @@ date_of_birth = 1979-05-27
 is_enabled = true
 ports = [ 8000, 8001, 8002 ]
 data_values = [ ["delta", "phi"], [3.14] ]
-temp_targets = { cpu = 79.5, case = 72.0 }
+TempTargets = { cpu = 79.5, case = 72.0 }
 
 [servers]
 

--- a/Tomlyn.Extensions.Configuration/TomlToSnakeCaseModifier.cs
+++ b/Tomlyn.Extensions.Configuration/TomlToSnakeCaseModifier.cs
@@ -1,0 +1,56 @@
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Extensions.Configuration;
+
+namespace Tomlyn.Extensions.Configuration;
+
+/// <summary>
+/// This class is used to allow the seamless binding between a .toml file that has snake_case keys (key_one = value)
+/// and pascal variables that are being bound (string KeyOne = "value"). The implementation stays relatively the same,
+/// BUT you need to use 'RemoveUnderscores' after you use '.Build()' when building the configuration, and before
+/// using '.Bind()' when you attempt to bind the configuration to some class that holds your pascal variables.
+///
+/// This can be achieved by using this line of code:
+/// 'var config = TomlToSnakeCaseModifier.RemoveUnderscores(configuration);'.
+/// </summary>
+public static class TomlToSnakeCaseModifier
+{
+    /// <summary>
+    /// This method creates a ConfigurationBuilder object that is modeled after the
+    /// configuration of the .toml file that is passed. It modifies the configuration keys
+    /// by removing underscores.
+    /// </summary>
+    /// <param name="configuration">Represents the configuration from a .toml file that has underscores.</param>
+    /// <returns>A new IConfiguration object with modified keys that have no underscores.</returns>
+    public static IConfiguration RemoveUnderscores(this IConfiguration configuration)
+    {
+        var newConfig = new ConfigurationBuilder();
+        AddStrippedKeys(configuration, newConfig, "");
+        return newConfig.Build();
+    }
+
+    /// <summary>
+    /// The method is designed to recursively iterate through a configuration structure,
+    /// modify its keys by removing underscores, and then add these modified key-value pairs
+    /// to a new IConfigurationBuilder.
+    /// </summary>
+    /// <param name="configuration">The IConfiguration representing the .toml file (has underscores).</param>
+    /// <param name="newConfig">The IConfiguration that is modified with keys that have no underscores.</param>
+    /// <param name="currentPath">Current path of the configuration key, separated by colons for nesting.</param>
+    private static void AddStrippedKeys(IConfiguration configuration, IConfigurationBuilder newConfig, string currentPath)
+    {
+        // Iterate through each key in the current configuration section
+        foreach (var child in configuration.GetChildren())
+        {
+            var strippedKey = child.Key.Replace("_", "");
+            var newPath = string.IsNullOrEmpty(currentPath) ? strippedKey : $"{currentPath}:{strippedKey}";
+
+            // If the current child has further children, recurse into them
+            if (child.GetChildren().Any())
+                AddStrippedKeys(child, newConfig, newPath);
+            else
+                // No more children, add the current configuration item to the builder
+                newConfig.AddInMemoryCollection(new Dictionary<string, string> { { newPath, child.Value } });
+        }
+    }
+}


### PR DESCRIPTION
I added an extension method with it's own class that is able to convert 'snake_case' keys into one line keys ('snakecase') by removing the underscores '_'. I ran into an issue where by design, the key has to match the variable represented in C#. What I mean by that is 'temp_targets' in the .toml file has to match 'Temp_Targets' which is just not visibly appealing code. The changes I made will now modify .toml keys that have underscores and convert them into code that can be read with the implementations @bugproof and @0xced made. So now, temp_targets will map to TempTargets which is much more appealing code. Keep in mind that if the new method `RemoveUnderscores` is used ALL bound C# variables must be PascalCase. 

I do plan on adding fixes for quoted and dashed keys in the future. These changes should be relatively easy.

I added extensive class and method comments in the newly added class called `TomlToSnakeCaseModifier`. 